### PR TITLE
Support primary shortcuts 🎉

### DIFF
--- a/Core/Model/Models.swift
+++ b/Core/Model/Models.swift
@@ -10,20 +10,20 @@ public struct Shortcut: Codable {
     public typealias Key = String
     public typealias Domain = String
 
-    let id: UInt
-    let key: Key
-    let url: URL
-    let title: String
-    let comment: String?
-    let domain: Domain
-    let openTimes: Int
-    let createdTime: Date
-    let favicon: URL?
+    public let id: UInt
+    public let key: Key
+    public let url: URL
+    public let title: String
+    public let comment: String?
+    public let domain: Domain
+    public let openTimes: Int
+    public let createdTime: Date
+    public let favicon: URL?
 
 }
 
-typealias PrimaryShortcutArray = [Shortcut]
-typealias SecondaryShortcutDictionary = [Shortcut.Domain: [Shortcut]]
+public typealias PrimaryShortcutArray = [Shortcut]
+public typealias SecondaryShortcutDictionary = [Shortcut.Domain: [Shortcut]]
 
 public struct ShortcutStorage: Storage {
 

--- a/Core/Model/ShortcutsManager.swift
+++ b/Core/Model/ShortcutsManager.swift
@@ -6,13 +6,13 @@
 import Foundation
 import os.log
 
-final class ShortcutManager {
-    static let shared = ShortcutManager()
+public final class ShortcutManager {
+    public static let shared = ShortcutManager()
 }
 
 // MARK: Fetch
 
-extension ShortcutManager {
+public extension ShortcutManager {
 
     func getPrimaryShortcuts() -> PrimaryShortcutArray {
         do {

--- a/anyshortcut.xcodeproj/project.pbxproj
+++ b/anyshortcut.xcodeproj/project.pbxproj
@@ -23,6 +23,9 @@
 		6458F5612426510D007671C4 /* Storage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6458F53024251442007671C4 /* Storage.swift */; };
 		6458F56224265110007671C4 /* Models.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6458F52E24250CC8007671C4 /* Models.swift */; };
 		6458F56324265114007671C4 /* ShortcutsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6458F52B24250B9A007671C4 /* ShortcutsManager.swift */; };
+		6458F56524265DD7007671C4 /* ShortcutMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6458F56424265DD7007671C4 /* ShortcutMonitor.swift */; };
+		6458F567242660AF007671C4 /* KeyCodes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6458F566242660AF007671C4 /* KeyCodes.swift */; };
+		6458F56824266595007671C4 /* Manifest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6458F549242649E2007671C4 /* Manifest.swift */; };
 		A3D507513A2257EF1484642C /* Pods_Core.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 838EE4B07AC13E32F38C3C22 /* Pods_Core.framework */; };
 		C148D9C71B288A9809D6D344 /* Pods_anyshortcut.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F702EC35A7CB7B5737C52F56 /* Pods_anyshortcut.framework */; };
 /* End PBXBuildFile section */
@@ -82,6 +85,8 @@
 		6458F55024265096007671C4 /* Core.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Core.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6458F55224265096007671C4 /* Core.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Core.h; sourceTree = "<group>"; };
 		6458F55324265096007671C4 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		6458F56424265DD7007671C4 /* ShortcutMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutMonitor.swift; sourceTree = "<group>"; };
+		6458F566242660AF007671C4 /* KeyCodes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyCodes.swift; sourceTree = "<group>"; };
 		838EE4B07AC13E32F38C3C22 /* Pods_Core.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Core.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A8FA9F0CAA245AB3B36CD1E5 /* Pods-Core.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Core.debug.xcconfig"; path = "Target Support Files/Pods-Core/Pods-Core.debug.xcconfig"; sourceTree = "<group>"; };
 		CEC2BC1426D8407587B74ABB /* Pods-anyshortcut.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-anyshortcut.release.xcconfig"; path = "Target Support Files/Pods-anyshortcut/Pods-anyshortcut.release.xcconfig"; sourceTree = "<group>"; };
@@ -151,6 +156,8 @@
 			isa = PBXGroup;
 			children = (
 				4C423F6C23A7E16E00584455 /* AppDelegate.swift */,
+				6458F56424265DD7007671C4 /* ShortcutMonitor.swift */,
+				6458F566242660AF007671C4 /* KeyCodes.swift */,
 				6458F5452425A9EA007671C4 /* MainWindowController.swift */,
 				4C423F6E23A7E16E00584455 /* ViewController.swift */,
 				4C423F7023A7E17000584455 /* Assets.xcassets */,
@@ -422,7 +429,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6458F56524265DD7007671C4 /* ShortcutMonitor.swift in Sources */,
 				4C423F6F23A7E16E00584455 /* ViewController.swift in Sources */,
+				6458F56824266595007671C4 /* Manifest.swift in Sources */,
+				6458F567242660AF007671C4 /* KeyCodes.swift in Sources */,
 				4C423F6D23A7E16E00584455 /* AppDelegate.swift in Sources */,
 				6458F5462425A9EA007671C4 /* MainWindowController.swift in Sources */,
 			);

--- a/anyshortcut/AppDelegate.swift
+++ b/anyshortcut/AppDelegate.swift
@@ -17,7 +17,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     func applicationDidFinishLaunching(_ aNotification: Notification) {
         // NSApp.setActivationPolicy(.accessory)
-        testGooglgMonitor()
+
+        ShortcutMonitor.register()
     }
 
     func applicationWillTerminate(_ aNotification: Notification) {
@@ -30,12 +31,4 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
 private extension AppDelegate {
 
-    func testGooglgMonitor() {
-        let shortcut = MASShortcut(keyCode: kVK_ANSI_G, modifierFlags: [.option, .command])
-        let url = URL(string: "https://google.com")!
-        MASShortcutMonitor.shared().register(shortcut, withAction: {
-            print("open \(url)")
-            NSWorkspace.shared.open(url)
-        })
-    }
 }

--- a/anyshortcut/KeyCodes.swift
+++ b/anyshortcut/KeyCodes.swift
@@ -1,0 +1,70 @@
+//
+// Created by Dylan Wang on 2020/3/21.
+// Copyright © 2020 anyshortcut. all rights reserved.
+// 
+
+import Foundation
+
+enum ANSIKey: String {
+
+    case a
+    case b
+    case c
+    case d
+    case e
+    case f
+    case g
+    case h
+    case i
+    case j
+    case k
+    case l
+    case m
+    case n
+    case o
+    case p
+    case q
+    case r
+    case s
+    case t
+    case u
+    case v
+    case w
+    case x
+    case y
+    case z
+
+    // US-ANSI Keyboard Positions
+    // eg. These key codes are for the physical key (in any keyboard layout)
+    // at the location of the named key in the US-ANSI layout.
+    var keyCode: Int {
+        switch self {
+        case .a: return 0x00
+        case .b: return 0x0B
+        case .c: return 0x08
+        case .d: return 0x02
+        case .e: return 0x0E
+        case .f: return 0x03
+        case .g: return 0x05
+        case .h: return 0x04
+        case .i: return 0x22
+        case .j: return 0x26
+        case .k: return 0x28
+        case .l: return 0x25
+        case .m: return 0x2E
+        case .n: return 0x2D
+        case .o: return 0x1F
+        case .p: return 0x23
+        case .q: return 0x0C
+        case .r: return 0x0F
+        case .s: return 0x01
+        case .t: return 0x11
+        case .u: return 0x20
+        case .v: return 0x09
+        case .w: return 0x0D
+        case .x: return 0x07
+        case .y: return 0x10
+        case .z: return 0x06
+        }
+    }
+}

--- a/anyshortcut/ShortcutMonitor.swift
+++ b/anyshortcut/ShortcutMonitor.swift
@@ -1,0 +1,47 @@
+//
+// Created by Dylan Wang on 2020/3/21.
+// Copyright © 2020 anyshortcut. all rights reserved.
+// 
+
+import Cocoa
+import Core
+import MASShortcut
+
+struct ShortcutMonitor {
+
+    static func register() {
+        registerPrimary()
+    }
+
+    static func registerPrimary() {
+        let primaryKey: NSEvent.ModifierFlags = .option
+        let primary = ShortcutManager.shared.getPrimaryShortcuts()
+        primary.forEach { shortcut in
+            MASShortcutMonitor.shared()?.register(shortcut.makeMASShortcut(with: primaryKey), withAction: {
+                print("open \(shortcut.url)")
+                NSWorkspace.shared.open(shortcut.url)
+            })
+        }
+    }
+
+    static func registerCompound() {
+        // TODO: issues here, MASShortcut may not support compound key, only compound modifier flags
+        let compound = ShortcutManager.shared.getCompoundShortcuts()
+        compound.forEach { shortcut in
+        }
+    }
+}
+
+extension Shortcut {
+    func makeMASShortcut(with primaryKey: NSEvent.ModifierFlags) -> MASShortcut? {
+        precondition(key.count == 1)
+        guard let ansiKey = ANSIKey(rawValue: key.lowercased()) else { return nil }
+        return MASShortcut(keyCode: ansiKey.keyCode, modifierFlags: primaryKey)
+    }
+
+    func compoundMASShort() -> MASShortcut? {
+        precondition(key.count == 2)
+        let elements = key.compactMap { ANSIKey(rawValue: $0.lowercased()) }
+        return nil
+    }
+}


### PR DESCRIPTION
This is a major PR: base logic just worked like magic.

1. Login with access token
2. Sync
3. Re-open the app 😂, all primary shortcut will valid.

Go for it, have fun. 

![image](https://user-images.githubusercontent.com/7845507/77230455-451aad80-6bcf-11ea-8cf6-2dd83306db5f.png)

Otherwise, I have an issue then: 

* compound shortcut may not be supported by MASShortcut.

I'll make more deeply research to find it out. If you have any idea, please let me know. @Folyd 